### PR TITLE
Add simple token-based login flow

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -96,6 +96,18 @@ body {
   gap: 24px;
 }
 
+.app__header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.app__header-content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .app__header h1 {
   margin: 0 0 8px;
   font-size: 32px;
@@ -129,6 +141,66 @@ body {
   font-size: 20px;
 }
 
+.auth-status {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.auth-status__user {
+  color: var(--text-brand);
+  font-weight: 600;
+}
+
+.auth-status button {
+  padding: 8px 14px;
+}
+
+.auth-container {
+  max-width: 420px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.auth-panel p {
+  margin-top: 0;
+  color: var(--text-secondary);
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.auth-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.auth-form label span {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.auth-form input {
+  width: 100%;
+}
+
+.auth-form button {
+  align-self: flex-start;
+}
+
+.auth-panel .message {
+  margin-top: 12px;
+}
+
 button {
   background: var(--brand-500);
   border: none;
@@ -138,6 +210,35 @@ button {
   font-size: 14px;
   cursor: pointer;
   transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+input,
+select,
+textarea {
+  font: inherit;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 12px;
+  background: var(--bg-surface);
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-sizing: border-box;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--brand-500);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.15);
+}
+
+@media (min-width: 768px) {
+  .app__header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
 }
 
 button:disabled {

--- a/src/main/java/com/marketplacehelper/auth/AuthController.java
+++ b/src/main/java/com/marketplacehelper/auth/AuthController.java
@@ -1,0 +1,44 @@
+package com.marketplacehelper.auth;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final SimpleAuthService authService;
+
+    public AuthController(SimpleAuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@Valid @RequestBody AuthRequest request) {
+        return authService.login(request.username(), request.password())
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body(Map.of(
+                                "error", "INVALID_CREDENTIALS",
+                                "message", "Неверный логин или пароль"
+                        )));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization) {
+        if (authorization != null && authorization.startsWith("Bearer ")) {
+            String token = authorization.substring(7);
+            authService.logout(token);
+        }
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/marketplacehelper/auth/AuthRequest.java
+++ b/src/main/java/com/marketplacehelper/auth/AuthRequest.java
@@ -1,0 +1,9 @@
+package com.marketplacehelper.auth;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AuthRequest(
+        @NotBlank(message = "Логин обязателен") String username,
+        @NotBlank(message = "Пароль обязателен") String password
+) {
+}

--- a/src/main/java/com/marketplacehelper/auth/AuthResponse.java
+++ b/src/main/java/com/marketplacehelper/auth/AuthResponse.java
@@ -1,0 +1,4 @@
+package com.marketplacehelper.auth;
+
+public record AuthResponse(String token, String username) {
+}

--- a/src/main/java/com/marketplacehelper/auth/SimpleAuthFilter.java
+++ b/src/main/java/com/marketplacehelper/auth/SimpleAuthFilter.java
@@ -1,0 +1,60 @@
+package com.marketplacehelper.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class SimpleAuthFilter extends OncePerRequestFilter {
+
+    private final SimpleAuthService authService;
+
+    public SimpleAuthFilter(SimpleAuthService authService) {
+        this.authService = authService;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        if (!path.startsWith("/api")) {
+            return true;
+        }
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            return true;
+        }
+        return path.startsWith("/api/auth")
+                || path.equals("/api/health")
+                || path.equals("/api/hello");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authorization != null && authorization.startsWith("Bearer ")) {
+            String token = authorization.substring(7);
+            if (authService.isTokenValid(token)) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+        }
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write("{\"error\":\"UNAUTHORIZED\",\"message\":\"Требуется авторизация\"}");
+        response.getWriter().flush();
+    }
+}

--- a/src/main/java/com/marketplacehelper/auth/SimpleAuthService.java
+++ b/src/main/java/com/marketplacehelper/auth/SimpleAuthService.java
@@ -1,0 +1,42 @@
+package com.marketplacehelper.auth;
+
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class SimpleAuthService {
+
+    private static final String DEFAULT_USERNAME = "iconzrus";
+    private static final String DEFAULT_PASSWORD = "iconzrus";
+
+    private final Map<String, Session> activeSessions = new ConcurrentHashMap<>();
+
+    public Optional<AuthResponse> login(String username, String password) {
+        if (DEFAULT_USERNAME.equals(username) && DEFAULT_PASSWORD.equals(password)) {
+            String token = UUID.randomUUID().toString();
+            activeSessions.put(token, new Session(username, Instant.now()));
+            return Optional.of(new AuthResponse(token, username));
+        }
+        return Optional.empty();
+    }
+
+    public boolean isTokenValid(String token) {
+        return activeSessions.containsKey(token);
+    }
+
+    public Optional<String> getUsernameByToken(String token) {
+        return Optional.ofNullable(activeSessions.get(token)).map(Session::username);
+    }
+
+    public void logout(String token) {
+        activeSessions.remove(token);
+    }
+
+    private record Session(String username, Instant issuedAt) {
+    }
+}


### PR DESCRIPTION
## Summary
- add a minimal auth controller, request/response DTOs and in-memory token service for the demo user
- protect API endpoints with a lightweight bearer-token filter while keeping health checks public
- gate the React UI behind a login form, persist the session token and attach it to subsequent API calls

## Testing
- `mvn -q test` *(fails: repository access is blocked in the execution environment)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cec17f794c83339876749a291ec5e4